### PR TITLE
Add comment to exported functions

### DIFF
--- a/internal/tests/ftypes/output.go
+++ b/internal/tests/ftypes/output.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 )
 
+// MarshalJSON marshals as JSON.
 func (x X) MarshalJSON() ([]byte, error) {
 	type X struct {
 		Int int
@@ -19,6 +20,7 @@ func (x X) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (x *X) UnmarshalJSON(input []byte) error {
 	type X struct {
 		Int *int

--- a/internal/tests/funcoverride/output.go
+++ b/internal/tests/funcoverride/output.go
@@ -8,6 +8,7 @@ import (
 
 var _ = (*Zo)(nil)
 
+// MarshalJSON marshals as JSON.
 func (z Z) MarshalJSON() ([]byte, error) {
 	type Z struct {
 		S              string `json:"s"`
@@ -23,6 +24,7 @@ func (z Z) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (z *Z) UnmarshalJSON(input []byte) error {
 	type Z struct {
 		S *string `json:"s"`
@@ -41,6 +43,7 @@ func (z *Z) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// MarshalYAML marshals as YAML.
 func (z Z) MarshalYAML() (interface{}, error) {
 	type Z struct {
 		S              string `json:"s"`
@@ -56,6 +59,7 @@ func (z Z) MarshalYAML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalYAML unmarshals from YAML.
 func (z *Z) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type Z struct {
 		S *string `json:"s"`
@@ -74,6 +78,7 @@ func (z *Z) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalTOML marshals as TOML.
 func (z Z) MarshalTOML() (interface{}, error) {
 	type Z struct {
 		S              string `json:"s"`
@@ -89,6 +94,7 @@ func (z Z) MarshalTOML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalTOML unmarshals from TOML.
 func (z *Z) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type Z struct {
 		S *string `json:"s"`

--- a/internal/tests/mapconv/output.go
+++ b/internal/tests/mapconv/output.go
@@ -8,6 +8,7 @@ import (
 
 var _ = (*Xo)(nil)
 
+// MarshalJSON marshals as JSON.
 func (x X) MarshalJSON() ([]byte, error) {
 	type X struct {
 		Map         map[replacedString]replacedInt
@@ -41,6 +42,7 @@ func (x X) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (x *X) UnmarshalJSON(input []byte) error {
 	type X struct {
 		Map         map[replacedString]replacedInt
@@ -73,6 +75,7 @@ func (x *X) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// MarshalYAML marshals as YAML.
 func (x X) MarshalYAML() (interface{}, error) {
 	type X struct {
 		Map         map[replacedString]replacedInt
@@ -106,6 +109,7 @@ func (x X) MarshalYAML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalYAML unmarshals from YAML.
 func (x *X) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type X struct {
 		Map         map[replacedString]replacedInt
@@ -138,6 +142,7 @@ func (x *X) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalTOML marshals as TOML.
 func (x X) MarshalTOML() (interface{}, error) {
 	type X struct {
 		Map         map[replacedString]replacedInt
@@ -171,6 +176,7 @@ func (x X) MarshalTOML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalTOML unmarshals from TOML.
 func (x *X) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type X struct {
 		Map         map[replacedString]replacedInt

--- a/internal/tests/nameclash/output.go
+++ b/internal/tests/nameclash/output.go
@@ -11,6 +11,7 @@ import (
 
 var _ = (*yo)(nil)
 
+// MarshalJSON marshals as JSON.
 func (y Y) MarshalJSON() ([]byte, error) {
 	type Y struct {
 		Foo    json0.Foo
@@ -28,6 +29,7 @@ func (y Y) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc0)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (y *Y) UnmarshalJSON(input []byte) error {
 	type Y struct {
 		Foo    *json0.Foo
@@ -58,6 +60,7 @@ func (y *Y) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// MarshalYAML marshals as YAML.
 func (y Y) MarshalYAML() (interface{}, error) {
 	type Y struct {
 		Foo    json0.Foo
@@ -75,6 +78,7 @@ func (y Y) MarshalYAML() (interface{}, error) {
 	return &enc0, nil
 }
 
+// UnmarshalYAML unmarshals from YAML.
 func (y *Y) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type Y struct {
 		Foo    *json0.Foo
@@ -105,6 +109,7 @@ func (y *Y) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalTOML marshals as TOML.
 func (y Y) MarshalTOML() (interface{}, error) {
 	type Y struct {
 		Foo    json0.Foo
@@ -122,6 +127,7 @@ func (y Y) MarshalTOML() (interface{}, error) {
 	return &enc0, nil
 }
 
+// UnmarshalTOML unmarshals from TOML.
 func (y *Y) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type Y struct {
 		Foo    *json0.Foo

--- a/internal/tests/omitempty/output.go
+++ b/internal/tests/omitempty/output.go
@@ -8,6 +8,7 @@ import (
 
 var _ = (*Xo)(nil)
 
+// MarshalJSON marshals as JSON.
 func (x X) MarshalJSON() ([]byte, error) {
 	type X struct {
 		Int replacedInt `json:",omitempty"`
@@ -17,6 +18,7 @@ func (x X) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (x *X) UnmarshalJSON(input []byte) error {
 	type X struct {
 		Int *replacedInt `json:",omitempty"`
@@ -31,6 +33,7 @@ func (x *X) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// MarshalYAML marshals as YAML.
 func (x X) MarshalYAML() (interface{}, error) {
 	type X struct {
 		Int replacedInt `json:",omitempty"`
@@ -40,6 +43,7 @@ func (x X) MarshalYAML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalYAML unmarshals from YAML.
 func (x *X) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type X struct {
 		Int *replacedInt `json:",omitempty"`
@@ -54,6 +58,7 @@ func (x *X) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalTOML marshals as TOML.
 func (x X) MarshalTOML() (interface{}, error) {
 	type X struct {
 		Int replacedInt `json:",omitempty"`
@@ -63,6 +68,7 @@ func (x X) MarshalTOML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalTOML unmarshals from TOML.
 func (x *X) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type X struct {
 		Int *replacedInt `json:",omitempty"`

--- a/internal/tests/reqfield/output.go
+++ b/internal/tests/reqfield/output.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 )
 
+// MarshalJSON marshals as JSON.
 func (x X) MarshalJSON() ([]byte, error) {
 	type X struct {
 		Required    int `gencodec:"required"`
@@ -18,6 +19,7 @@ func (x X) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (x *X) UnmarshalJSON(input []byte) error {
 	type X struct {
 		Required    *int `gencodec:"required"`

--- a/internal/tests/sliceconv/output.go
+++ b/internal/tests/sliceconv/output.go
@@ -8,6 +8,7 @@ import (
 
 var _ = (*Xo)(nil)
 
+// MarshalJSON marshals as JSON.
 func (x X) MarshalJSON() ([]byte, error) {
 	type X struct {
 		Slice       []replacedInt
@@ -43,6 +44,7 @@ func (x X) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&enc)
 }
 
+// UnmarshalJSON unmarshals from JSON.
 func (x *X) UnmarshalJSON(input []byte) error {
 	type X struct {
 		Slice       []replacedInt
@@ -79,6 +81,7 @@ func (x *X) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+// MarshalYAML marshals as YAML.
 func (x X) MarshalYAML() (interface{}, error) {
 	type X struct {
 		Slice       []replacedInt
@@ -114,6 +117,7 @@ func (x X) MarshalYAML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalYAML unmarshals from YAML.
 func (x *X) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type X struct {
 		Slice       []replacedInt
@@ -150,6 +154,7 @@ func (x *X) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalTOML marshals as TOML.
 func (x X) MarshalTOML() (interface{}, error) {
 	type X struct {
 		Slice       []replacedInt
@@ -185,6 +190,7 @@ func (x X) MarshalTOML() (interface{}, error) {
 	return &enc, nil
 }
 
+// UnmarshalTOML unmarshals from TOML.
 func (x *X) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type X struct {
 		Slice       []replacedInt

--- a/main.go
+++ b/main.go
@@ -125,10 +125,10 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/garslo/gogen"
 	"golang.org/x/tools/go/buildutil"
 	"golang.org/x/tools/go/loader"
 	"golang.org/x/tools/imports"
-    "github.com/garslo/gogen"
 )
 
 func main() {
@@ -250,7 +250,7 @@ func generate(mtyp *marshalerType, cfg *Config) ([]byte, error) {
 		writeUseOfOverride(w, mtyp.override, mtyp.scope.qualify)
 	}
 	for _, format := range cfg.Formats {
-        var genMarshal, genUnmarshal gogen.Function
+		var genMarshal, genUnmarshal gogen.Function
 		switch format {
 		case "json":
 			genMarshal = genMarshalJSON(mtyp)

--- a/main.go
+++ b/main.go
@@ -264,11 +264,11 @@ func generate(mtyp *marshalerType, cfg *Config) ([]byte, error) {
 		default:
 			return nil, fmt.Errorf("unknown format: %q", format)
 		}
-		fmt.Fprintf(w, "// %s marshals type %s to a %s string", genMarshal.Name, mtyp.name, format)
+		fmt.Fprintf(w, "// %s marshals as %s.", genMarshal.Name, strings.ToUpper(format))
 		fmt.Fprintln(w)
 		writeFunction(w, mtyp.fs, genMarshal)
 		fmt.Fprintln(w)
-		fmt.Fprintf(w, "// %s unmarshals type %s to a %s string", genUnmarshal.Name, mtyp.name, format)
+		fmt.Fprintf(w, "// %s unmarshals from %s.", genUnmarshal.Name, strings.ToUpper(format))
 		fmt.Fprintln(w)
 		writeFunction(w, mtyp.fs, genUnmarshal)
 		fmt.Fprintln(w)

--- a/main.go
+++ b/main.go
@@ -268,6 +268,8 @@ func generate(mtyp *marshalerType, cfg *Config) ([]byte, error) {
 		fmt.Fprintln(w)
 		writeFunction(w, mtyp.fs, genMarshal)
 		fmt.Fprintln(w)
+		fmt.Fprintf(w, "// %s unmarshals type %s to a %s string", genUnmarshal.Name, mtyp.name, format)
+		fmt.Fprintln(w)
 		writeFunction(w, mtyp.fs, genUnmarshal)
 		fmt.Fprintln(w)
 	}


### PR DESCRIPTION
Through this PR, the marshal and unmarshal functions are preceded by a comment including their names, which is now a requirement for exported functions in Go.