### PR TITLE
feat: make project importable for version pinning on Go <= 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@ The generated methods add features which json and other marshaling packages cann
 	gencodec -dir . -type MyType -formats json,yaml,toml -out mytype_json.go
 
 See [the documentation for more details](https://godoc.org/github.com/fjl/gencodec).
+
+To pin a specific version of gencodec in your project, you can use, for example for version v0.1.0:
+
+- For Go >= 1.24, use `go get -tool github.com/fjl/gencodec@v0.1.0`
+- For Go <= 1.23:
+  1. Add the tool dependency with `go get github.com/fjl/gencodec@v0.1.0`
+  1. Create a `tools.go` file at the root of your project with content:
+
+    ```go
+    package yourproject
+
+    import (
+        _ "github.com/fjl/gencodec/importable"
+    )
+    ```
+
+  1. Run `go mod tidy`

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ To pin a specific version of gencodec in your project, you can use, for example 
   1. Add the tool dependency with `go get github.com/fjl/gencodec@v0.1.0`
   1. Create a `tools.go` file at the root of your project with content:
 
-    ```go
-    package yourproject
+      ```go
+      package yourproject
 
-    import (
-        _ "github.com/fjl/gencodec/importable"
-    )
-    ```
+      import (
+          _ "github.com/fjl/gencodec/importable"
+      )
+      ```
 
   1. Run `go mod tidy`

--- a/importable/importable.go
+++ b/importable/importable.go
@@ -1,0 +1,5 @@
+// Package importable is only defined in order for consumers of this program
+// to be able to specify the import path of this package in a tools.go file,
+// which is required for projects running Go < 1.24.
+// This package is not intended to be used by any other means.
+package importable


### PR DESCRIPTION
- create importable/importable.go with only a comment describing its use
- Add readme documentation on how to pin a specific version in your Go project

Otherwise trying to import the project as `_ "github.com/fjl/gencodec"` produces an error because it's not an importable package and is a program only.