### PR TITLE
Support aliased types in overrides

### DIFF
--- a/internal/tests/alias/input.go
+++ b/internal/tests/alias/input.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license,
 // which can be found in the LICENSE file.
 
-//go:generate go run github.com/fjl/gencodec -type X -out output.go
+//go:generate go run github.com/fjl/gencodec -type X -field-override xOverride -out output.go
 
 package alias
 
@@ -19,10 +19,20 @@ type (
 	// Demonstrate recursive unaliasing
 	intermediate = big.Int
 	AliasedTwice = intermediate
+
+	Element      struct{}
+	ElementDeriv Element
+	Slice        []Element
+	SliceAlias   = Slice
 )
 
 type X struct {
 	A Aliased
 	B AliasedTwice
 	C other.Int
+	D SliceAlias
+}
+
+type xOverride struct {
+	D []ElementDeriv
 }

--- a/internal/tests/alias/output.go
+++ b/internal/tests/alias/output.go
@@ -8,17 +8,26 @@ import (
 	"github.com/fjl/gencodec/internal/tests/alias/other"
 )
 
+var _ = (*xOverride)(nil)
+
 // MarshalJSON marshals as JSON.
 func (x X) MarshalJSON() ([]byte, error) {
 	type X struct {
 		A Aliased
 		B AliasedTwice
 		C other.Int
+		D []ElementDeriv
 	}
 	var enc X
 	enc.A = x.A
 	enc.B = x.B
 	enc.C = x.C
+	if x.D != nil {
+		enc.D = make([]ElementDeriv, len(x.D))
+		for k, v := range x.D {
+			enc.D[k] = ElementDeriv(v)
+		}
+	}
 	return json.Marshal(&enc)
 }
 
@@ -28,6 +37,7 @@ func (x *X) UnmarshalJSON(input []byte) error {
 		A *Aliased
 		B *AliasedTwice
 		C *other.Int
+		D []ElementDeriv
 	}
 	var dec X
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -41,6 +51,12 @@ func (x *X) UnmarshalJSON(input []byte) error {
 	}
 	if dec.C != nil {
 		x.C = *dec.C
+	}
+	if dec.D != nil {
+		x.D = make(SliceAlias, len(dec.D))
+		for k, v := range dec.D {
+			x.D[k] = Element(v)
+		}
 	}
 	return nil
 }

--- a/types_util.go
+++ b/types_util.go
@@ -101,6 +101,8 @@ func underlying[T types.Type](typ types.Type) T {
 		switch t := typ.(type) {
 		case *types.Named:
 			typ = t.Underlying()
+		case *types.Alias:
+			typ = t.Rhs()
 		case T:
 			return t
 		default:


### PR DESCRIPTION
When overriding an aliased type for which conversion is required, the eventual calls to `underlying()` via `checkConvertible()` used to return `nil`. This change resolves the alias inside the `underlying()` loop, resulting in the true underlying `T`.

I appreciate that the scenario in the test may seem contrived, but it's representative of a scenario I encountered during a refactor via type aliases.